### PR TITLE
Fix home sidebar and add product network error

### DIFF
--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -23,11 +23,16 @@ export const AuthInterceptor: HttpInterceptorFn = (req, next) => {
   
   if (token) {
     console.log('🔑 AuthInterceptor: Adding token to request headers');
+    // Do not set Content-Type for FormData; the browser must set the multipart boundary automatically
+    const isFormData = (req.body instanceof FormData);
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${token}`
+    };
+    if (!isFormData) {
+      headers['Content-Type'] = req.headers.get('Content-Type') || 'application/json';
+    }
     const authReq = req.clone({
-      setHeaders: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': req.headers.get('Content-Type') || 'application/json'
-      }
+      setHeaders: headers
     });
     
     return next(authReq).pipe(

--- a/frontend/src/app/customer/layout/customer-layout.component.ts
+++ b/frontend/src/app/customer/layout/customer-layout.component.ts
@@ -17,7 +17,7 @@ import { CartService } from '../../core/services/cart.service';
            (click)="closeSidebar()"></div>
 
       <!-- Sidebar -->
-      <aside class="fixed top-0 left-0 z-50 w-72 h-screen bg-white shadow-xl border-r border-gray-200 transform transition-transform duration-300 ease-in-out"
+      <aside *ngIf="!isHomeRoute()" class="fixed top-0 left-0 z-50 w-72 h-screen bg-white shadow-xl border-r border-gray-200 transform transition-transform duration-300 ease-in-out"
              [class.translate-x-0]="!isMobile || sidebarOpen"
              [class.-translate-x-full]="isMobile && !sidebarOpen">
         
@@ -184,7 +184,7 @@ import { CartService } from '../../core/services/cart.service';
       </aside>
 
       <!-- Main Content -->
-      <div class="transition-all duration-300 ease-in-out" [class.ml-72]="!isMobile">
+      <div class="transition-all duration-300 ease-in-out" [class.ml-72]="!isMobile && !isHomeRoute()">
         <!-- Top Header -->
         <header class="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-30">
           <div class="px-6 py-4">
@@ -284,6 +284,7 @@ export class CustomerLayoutComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadCartCount();
+    this.currentRoute = this.router.url;
   }
 
   @HostListener('window:resize', ['$event'])
@@ -344,6 +345,10 @@ export class CustomerLayoutComponent implements OnInit {
     };
     
     return routeTitles[this.currentRoute] || 'Customer Portal';
+  }
+
+  isHomeRoute(): boolean {
+    return this.currentRoute === '/customer/home' || this.currentRoute === '/customer' || this.currentRoute === '/home/home' || this.currentRoute === '/home';
   }
 
   getPageSubtitle(): string {


### PR DESCRIPTION
Remove sidebar from home routes and fix `FormData` Content-Type handling in the auth interceptor.

The `NetworkError` on the add product page was caused by the auth interceptor overriding the `Content-Type` header for `FormData` requests. Browsers must set the `multipart/form-data` header with its boundary automatically for file uploads to work correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f595234e-b62a-4bac-8068-f5babd647436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f595234e-b62a-4bac-8068-f5babd647436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

