### PR TITLE
Hide sidebar for logged out customers

### DIFF
--- a/frontend/src/app/customer/layout/customer-layout.component.ts
+++ b/frontend/src/app/customer/layout/customer-layout.component.ts
@@ -356,9 +356,11 @@ export class CustomerLayoutComponent implements OnInit {
   }
 
   shouldShowSidebar(): boolean {
-    // Hide on home always; show on marketplace only if logged in
+    // Hide on home always; show on marketplace and products only if logged in
     if (this.isHomeRoute()) return false;
     if (this.isMarketplaceRoute()) return this.authService.isLoggedIn();
+    if (this.currentRoute === '/customer/products') return this.authService.isLoggedIn();
+    if (this.currentRoute.startsWith('/customer/products/')) return this.authService.isLoggedIn();
     return true;
   }
 


### PR DESCRIPTION
Hide the sidebar for logged-out users on `/customer/products` and `/customer/products/:id` routes.

The `shouldShowSidebar` method in `CustomerLayoutComponent` was updated to ensure that public product pages do not display a sidebar for logged-out customers, aligning with the existing behavior for the marketplace route.

---
<a href="https://cursor.com/background-agent?bcId=bc-31033aa0-62a1-416a-b540-2ab3a7d240f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31033aa0-62a1-416a-b540-2ab3a7d240f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

