### PR TITLE
Fix number comparison in dashboard component

### DIFF
--- a/frontend/src/app/customer/dashboard/dashboard.component.ts
+++ b/frontend/src/app/customer/dashboard/dashboard.component.ts
@@ -198,16 +198,10 @@ export class CustomerDashboardComponent implements OnInit {
 
   // Method to handle price input changes
   onPriceInputChange(): void {
-    // Validate and convert price inputs
+    // Coerce inputs to numbers or null, then validate
+    this.minPrice = this.safeNumberValue(this.minPrice);
+    this.maxPrice = this.safeNumberValue(this.maxPrice);
     this.validatePriceInputs();
-    
-    // Ensure values are properly typed
-    if (this.minPrice === '') {
-      this.minPrice = null;
-    }
-    if (this.maxPrice === '') {
-      this.maxPrice = null;
-    }
   }
 
   get filteredRecommended(): any[] {


### PR DESCRIPTION
Remove invalid string comparisons for `minPrice` and `maxPrice` to resolve `TS2367` type errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a8f5788-a7fc-479e-a039-faf2ffe534e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a8f5788-a7fc-479e-a039-faf2ffe534e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

